### PR TITLE
[2/?] Clear gtf annotation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -218,7 +218,7 @@ pub struct ReadMappings {
     duplicated: usize,
     ambiguous: usize,
     ambiguous_pair: usize,
-    notinref: usize,
+    notingtf: usize,
     mapq: usize,
     nohit: usize,
     hit: Vec<usize>
@@ -253,7 +253,7 @@ impl ReadMappings {
         writeln!(w, "marked_duplicated\t{}", self.duplicated)?;
         writeln!(w, "ambiguous\t{}", self.ambiguous)?;
         writeln!(w, "ambiguous_pair\t{}", self.ambiguous_pair)?;
-        writeln!(w, "chr_not_in_ref\t{}", self.notinref)?;
+        writeln!(w, "chr_not_in_gtf\t{}", self.notingtf)?;
         writeln!(w, "nohit\t{}", self.nohit)?;
 
         Ok(())
@@ -278,7 +278,7 @@ pub fn quantify_bam<P: AsRef<Path>>(bam_file: P, config: Config, genemap: &GeneM
             }
         }).collect();
 
-    //quantify 
+    //quantify
     let mut delayed = HashMap::new();
     let mut counts = ReadMappings::new(genemap.genes.len());
 
@@ -334,8 +334,8 @@ pub fn quantify_bam<P: AsRef<Path>>(bam_file: P, config: Config, genemap: &GeneM
                     counts.count_hit(map_segments(&record, ref_chr_map, config));
                 }
             } else {
-                //no reference for this chr in the bam
-                counts.notinref += 1;
+                // this chr was not in the gtf
+                counts.notingtf += 1;
             }
     }
     Ok(counts)

--- a/src/app.rs
+++ b/src/app.rs
@@ -67,13 +67,12 @@ impl Strandness {
         };
 
         match (self, target) {
-            (Strandness::Forward, Strand::Foward) => fragment_forward,
-            (Strandness::Forward, Strand::Reverse) => !fragment_forward,
-            (Strandness::Forward, Strand::Unknown) => true,
-            (Strandness::Reverse, Strand::Foward) => !fragment_forward,
+            (Strandness::Unstranded, _) => unreachable!(),
+            (_, Strand::Unknown) => true,
+            (Strandness::Forward, Strand::Forward) |
             (Strandness::Reverse, Strand::Reverse) => fragment_forward,
-            (Strandness::Reverse, Strand::Unknown) => true,
-            (Strandness::Unstranded, _) => unreachable!()
+            (Strandness::Forward, Strand::Reverse) |
+            (Strandness::Reverse, Strand::Forward) => !fragment_forward,
         }
     }
 }

--- a/src/gtf.rs
+++ b/src/gtf.rs
@@ -81,7 +81,7 @@ pub struct GtfExon<'a> {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Strand {
-    Foward,
+    Forward,
     Reverse,
     Unknown
 }
@@ -90,7 +90,7 @@ impl FromStr for Strand {
     type Err = &'static str;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "+" => Ok(Strand::Foward),
+            "+" => Ok(Strand::Forward),
             "-" => Ok(Strand::Reverse),
             "." => Ok(Strand::Unknown),
             _ => Err("GTF strand not +/-/.")


### PR DESCRIPTION
While iterating over bam records we can skip if not in gtf, but all observed contigs should be in the bam file.