### PR TITLE
[4/?] Use bam header to check gtf

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -218,7 +218,7 @@ pub struct ReadMappings {
     duplicated: usize,
     ambiguous: usize,
     ambiguous_pair: usize,
-    notinref: usize,
+    notingtf: usize,
     mapq: usize,
     nohit: usize,
     hit: Vec<usize>
@@ -253,7 +253,7 @@ impl ReadMappings {
         writeln!(w, "marked_duplicated\t{}", self.duplicated)?;
         writeln!(w, "ambiguous\t{}", self.ambiguous)?;
         writeln!(w, "ambiguous_pair\t{}", self.ambiguous_pair)?;
-        writeln!(w, "chr_not_in_ref\t{}", self.notinref)?;
+        writeln!(w, "chr_not_in_gtf\t{}", self.notingtf)?;
         writeln!(w, "nohit\t{}", self.nohit)?;
 
         Ok(())
@@ -278,7 +278,7 @@ pub fn quantify_bam<P: AsRef<Path>>(bam_file: P, config: Config, genemap: &GeneM
             }
         }).collect();
 
-    //quantify 
+    //quantify
     let mut delayed = HashMap::new();
     let mut counts = ReadMappings::new(genemap.genes.len());
 
@@ -334,8 +334,8 @@ pub fn quantify_bam<P: AsRef<Path>>(bam_file: P, config: Config, genemap: &GeneM
                     counts.count_hit(map_segments(&record, ref_chr_map, config));
                 }
             } else {
-                //no reference for this chr in the bam
-                counts.notinref += 1;
+                // this chr was not in the gtf
+                counts.notingtf += 1;
             }
     }
     Ok(counts)

--- a/src/app.rs
+++ b/src/app.rs
@@ -56,12 +56,11 @@ impl Strandness {
         if self == Strandness::Unstranded {
             return true;
         }
-        
+
         // Asuming a FR library ( --->____<--- )
         // Determine if fragment is forward
         let fragment_forward = if r.is_paired() {
-            (r.is_first_in_template() && !r.is_reverse()) ||
-                (r.is_last_in_template() && r.is_reverse())
+            if r.is_reverse() { r.is_last_in_template() } else { r.is_first_in_template() }
         } else {
             !r.is_reverse()
         };
@@ -188,8 +187,8 @@ impl GeneMap {
             v.dedup(); //deduplication saves around 50% because of comparable isoforms (and havanna entries)
             numexonsdd += v.len();
             NClist::from_vec(v)
-                .map_err(|_| anyhow!("Cannot create interval search list, all ranges must be > 1"))
-        }).collect::<Result<_, _>>()?;
+        }).collect::<Result<_, _>>()
+        .map_err(|_| anyhow!("Cannot create interval search list, all ranges must be > 1"))?;
 
         eprintln!("{} lines in GTF, parsed {} exons, {} unique geneid-exon ranges", n, numexons, numexonsdd);
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -67,13 +67,12 @@ impl Strandness {
         };
 
         match (self, target) {
-            (Strandness::Forward, Strand::Foward) => fragment_forward,
-            (Strandness::Forward, Strand::Reverse) => !fragment_forward,
-            (Strandness::Forward, Strand::Unknown) => true,
-            (Strandness::Reverse, Strand::Foward) => !fragment_forward,
+            (Strandness::Unstranded, _) => unreachable!(),
+            (_, Strand::Unknown) => true,
+            (Strandness::Forward, Strand::Forward) |
             (Strandness::Reverse, Strand::Reverse) => fragment_forward,
-            (Strandness::Reverse, Strand::Unknown) => true,
-            (Strandness::Unstranded, _) => unreachable!()
+            (Strandness::Forward, Strand::Reverse) |
+            (Strandness::Reverse, Strand::Forward) => !fragment_forward,
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -152,10 +152,10 @@ impl GeneMap {
 
             if let Some(r) = reader.parse_exon()? {
 
-                let gene_idx = if !genes.contains(r.seq_name) {
-                    genes.insert_full(r.seq_name.to_owned()).0
+                let gene_idx = if !genes.contains(r.id) {
+                    genes.insert_full(r.id.to_owned()).0
                 } else {
-                    genes.get_full(r.seq_name).unwrap().0
+                    genes.get_full(r.id).unwrap().0
                 };
 
                 let chr_idx = if !seq_names.contains(r.seq_name) {

--- a/src/gtf.rs
+++ b/src/gtf.rs
@@ -81,7 +81,7 @@ pub struct GtfExon<'a> {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Strand {
-    Foward,
+    Forward,
     Reverse,
     Unknown
 }
@@ -90,7 +90,7 @@ impl FromStr for Strand {
     type Err = &'static str;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "+" => Ok(Strand::Foward),
+            "+" => Ok(Strand::Forward),
             "-" => Ok(Strand::Reverse),
             "." => Ok(Strand::Unknown),
             _ => Err("GTF strand not +/-/.")


### PR DESCRIPTION
deze is wat interessanter

use bam header to check gtf for extrinsic contigs

First read bam header so that we can abort when gtf contains unexpected
contigs. This now occurs in main.