### PR TITLE
Add --seq-types [exon,..] and --use-supplementary options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-htslib = "0.39"
 nclist = "0.1.1"
 anyhow = "1.0.27"
 indexmap = "1.3.2"
-clap = "2.33.0"
+clap = { version = "4.0.29", features = ["derive"] }
 itoa = "0.4.5"
 atoi = "0.4.0"
 niffler = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ clap = { version = "4.0.29", features = ["derive"] }
 itoa = "0.4.5"
 atoi = "0.4.0"
 niffler = "2.2.0"
+itertools = "0.10.5"

--- a/src/app.rs
+++ b/src/app.rs
@@ -264,7 +264,10 @@ impl ReadMappings {
 
 pub fn quantify_bam<P: AsRef<Path>>(bam_file: P, config: Config, genemap: &GeneMap) -> Result<ReadMappings> {
     //open bam
-    let mut bam = bam::Reader::from_path(bam_file)?;
+    let mut bam = match bam_file.as_ref().to_str() {
+        Some("/dev/stdin") | Some("-") => bam::Reader::from_stdin()?,
+        _ => bam::Reader::from_path(bam_file)?,
+    };
     // test from command line show improve until 4 cpu's
     bam.set_threads(4)?;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use std::time::Instant;
 
 use clap::ValueEnum;
+use itertools::Itertools;
 
 use anyhow::{anyhow, Result};
 use indexmap::IndexSet;
@@ -20,7 +21,7 @@ use crate::{
 #[derive(ValueEnum, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum QuantMethod {
     Union,
-    Strict
+    Strict,
 }
 
 impl FromStr for QuantMethod {
@@ -29,7 +30,7 @@ impl FromStr for QuantMethod {
         match s {
             "strict" => Ok(QuantMethod::Strict),
             "union" => Ok(QuantMethod::Union),
-            _ => Err("Unknown quantification method")
+            _ => Err("Unknown quantification method"),
         }
     }
 }
@@ -38,7 +39,7 @@ impl FromStr for QuantMethod {
 pub enum Strandness {
     Forward,
     Reverse,
-    Unstranded
+    Unstranded,
 }
 
 impl Strandness {
@@ -47,22 +48,24 @@ impl Strandness {
         if self == Strandness::Unstranded {
             return true;
         }
-        
+
         // Asuming a FR library ( --->____<--- )
         // Determine if fragment is forward
         let fragment_forward = if r.is_paired() {
-            (r.is_first_in_template() && !r.is_reverse()) ||
-                (r.is_last_in_template() && r.is_reverse())
+            (r.is_first_in_template() && !r.is_reverse())
+                || (r.is_last_in_template() && r.is_reverse())
         } else {
             !r.is_reverse()
         };
 
         match (self, target) {
             (_, Strand::Unknown) => true,
-            (Strandness::Forward, Strand::Forward) |
-            (Strandness::Reverse, Strand::Reverse) => fragment_forward,
-            (Strandness::Forward, Strand::Reverse) |
-            (Strandness::Reverse, Strand::Forward) => !fragment_forward,
+            (Strandness::Forward, Strand::Forward) | (Strandness::Reverse, Strand::Reverse) => {
+                fragment_forward
+            }
+            (Strandness::Forward, Strand::Reverse) | (Strandness::Reverse, Strand::Forward) => {
+                !fragment_forward
+            }
             (Strandness::Unstranded, _) => unreachable!(),
         }
     }
@@ -75,36 +78,40 @@ impl FromStr for Strandness {
             "F" => Ok(Strandness::Forward),
             "R" => Ok(Strandness::Reverse),
             "U" => Ok(Strandness::Unstranded),
-            _ => Err("Unknown strandness")
+            _ => Err("Unknown strandness"),
         }
     }
 }
 
-/// Exon is defined by it's coordinates and references a parent Gene
+/// Section is defined by it's coordinates and references a parent Gene
 #[derive(Debug, Eq, PartialEq)]
-struct Exon {
+struct Section {
     id: usize,
     strand: Strand,
     range: Range<i64>,
 }
 
-impl Ord  for Exon {
+impl Ord for Section {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.id.cmp(&other.id)
+        self.id
+            .cmp(&other.id)
             .then(self.range.start.cmp(&other.range.start))
             .then(self.range.end.cmp(&other.range.end))
     }
 }
 
-impl PartialOrd  for Exon {
+impl PartialOrd for Section {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.id.cmp(&other.id)
-            .then(self.range.start.cmp(&other.range.start))
-            .then(self.range.end.cmp(&other.range.end)))
+        Some(
+            self.id
+                .cmp(&other.id)
+                .then(self.range.start.cmp(&other.range.start))
+                .then(self.range.end.cmp(&other.range.end)),
+        )
     }
 }
 
-impl Interval for Exon {
+impl Interval for Section {
     type Coord = i64;
     fn start(&self) -> &Self::Coord {
         &self.range.start
@@ -126,7 +133,7 @@ fn get_index_or_insert_owned(map: &mut IndexSet<Vec<u8>>, v: &[u8]) -> usize {
 pub struct GeneMap {
     genes: IndexSet<Vec<u8>>,
     seq_names: IndexSet<Vec<u8>>,
-    intervals: Vec<NClist<Exon>>,
+    intervals: Vec<NClist<Section>>,
 }
 
 impl GeneMap {
@@ -135,11 +142,10 @@ impl GeneMap {
         let t0 = Instant::now();
         let (r, _compression) = niffler::from_path(config.gtf.as_str())?;
         let mut reader = GtfReader::new(r);
-        
+
         let mut genes = IndexSet::new();
         let mut seq_names = IndexSet::new();
-        let mut exons = Vec::new();
-
+        let mut sections = Vec::new();
 
         //iterate records
         let mut record = GtfRecord::new();
@@ -150,56 +156,75 @@ impl GeneMap {
             }
             n += 1;
 
-            if let Some(r) = record.parse_exon(&config.seq_types)? {
+            if let Some(r) = record.parse_seqtype(&config.seq_types)? {
                 let gene_idx = get_index_or_insert_owned(&mut genes, r.id);
                 let chr_idx = get_index_or_insert_owned(&mut seq_names, r.seq_name);
 
-                 if r.end - r.start < 0 {
-                     eprintln!("Skipping zero/negative width exon: {}", record);
-                     continue;
-                 }
-
-                if exons.len() == chr_idx {
-                    exons.push(Vec::new());
+                if r.end - r.start < 0 {
+                    eprintln!("Skipping zero/negative width segment: {}", record);
+                    continue;
                 }
 
-                // gtf exon coordinates are 1 based and closed end
+                if sections.len() == chr_idx {
+                    sections.push(Vec::new());
+                }
+
+                // gtf segment coordinates are 1 based and closed end
                 // bam files are 0 based, and nclist expects half open
-                exons[chr_idx].push(Exon {id: gene_idx, strand: r.strand, range: r.start-1..r.end });
+                sections[chr_idx].push(Section {
+                    id: gene_idx,
+                    strand: r.strand,
+                    range: r.start - 1..r.end,
+                });
             }
         }
         let gtftime = t0.elapsed();
 
         //Create the NClists
-        let mut numexons = 0;
-        let mut numexonsdd = 0;
-        let intervals = exons.into_iter()
+        let mut numsections = 0;
+        let mut numsectionsdd = 0;
+        let intervals = sections
+            .into_iter()
             .map(|mut v| {
-                numexons += v.len();
+                numsections += v.len();
                 v.sort();
                 v.dedup(); //deduplication saves around 50% because of comparable isoforms (and havanna entries)
-            numexonsdd += v.len();
-            NClist::from_vec(v) })
+                numsectionsdd += v.len();
+                NClist::from_vec(v)
+            })
             .collect::<Result<_, _>>()
             .map_err(|_| anyhow!("Cannot create interval search list, all ranges must be > 1"))?;
 
-        eprintln!("{} lines in GTF, parsed {} exons, {} unique geneid-exon ranges ({:?})", n, numexons, numexonsdd, gtftime);
+        let mut seq_types = config.seq_types.iter().cloned().collect::<Vec<_>>();
+        seq_types.sort();
 
-        Ok(GeneMap { genes, seq_names, intervals })
+        let mut target = seq_types.pop().expect("No seq_types?");
+        if !seq_types.is_empty() {
+            target = format!("{} and -{target}", seq_types.drain(..).join(", -"));
+        }
+
+        eprintln!(
+            "{n} lines in GTF, parsed {numsections} sections, {numsectionsdd} unique geneid-{target} ranges ({gtftime:?})"
+        );
+
+        Ok(GeneMap {
+            genes,
+            seq_names,
+            intervals,
+        })
     }
 
     #[inline]
     pub fn hit_name(&self, i: usize) -> Option<&Vec<u8>> {
         self.genes.get_index(i)
     }
-
 }
 
 #[derive(Eq, PartialEq)]
 enum SegmentHit {
     Hit(usize),
     Nohit,
-    Ambiguous
+    Ambiguous,
 }
 
 #[derive(Default)]
@@ -213,12 +238,15 @@ pub struct ReadMappings {
     notingtf: usize,
     mapq: usize,
     nohit: usize,
-    hit: Vec<usize>
+    hit: Vec<usize>,
 }
 
 impl ReadMappings {
     pub fn new(n: usize) -> ReadMappings {
-        ReadMappings { hit: vec![0; n], ..Default::default() }
+        ReadMappings {
+            hit: vec![0; n],
+            ..Default::default()
+        }
     }
 
     fn count_hit(&mut self, h: &SegmentHit) {
@@ -230,7 +258,6 @@ impl ReadMappings {
     }
 
     pub fn write<W: Write>(&self, o: W, genes: &GeneMap) -> Result<()> {
-
         let mut w = BufWriter::new(o);
         for (geneidx, &count) in self.hit.iter().enumerate() {
             w.write_all(genes.hit_name(geneidx).unwrap())?;
@@ -264,8 +291,11 @@ pub fn quantify_bam(config: &Config, genemap: &GeneMap) -> Result<ReadMappings> 
 
     //intersect header chr list with rr
     let header = bam.header();
-    let tid_map: Vec<_> = header.target_names().iter()
-        .map(|name| genemap.seq_names.iter().position(|n| name == &n.as_slice())).collect();
+    let tid_map: Vec<_> = header
+        .target_names()
+        .iter()
+        .map(|name| genemap.seq_names.iter().position(|n| name == &n.as_slice()))
+        .collect();
 
     //quantify
     let mut delayed = HashMap::new();
@@ -273,111 +303,111 @@ pub fn quantify_bam(config: &Config, genemap: &GeneMap) -> Result<ReadMappings> 
 
     for record in bam.records() {
         let record = record?;
-            if record.is_unmapped() {
-                counts.unmapped += 1;
-                continue;
-            }
+        if record.is_unmapped() {
+            counts.unmapped += 1;
+            continue;
+        }
 
-            if record.is_quality_check_failed() {
-                counts.qc_failed += 1;
-                continue;
-            }
-            if record.is_secondary() || (record.is_supplementary() && !config.use_supplementary) {
-                counts.secondary += 1;
-                continue;
-            }
+        if record.is_quality_check_failed() {
+            counts.qc_failed += 1;
+            continue;
+        }
+        if record.is_secondary() || (record.is_supplementary() && !config.use_supplementary) {
+            counts.secondary += 1;
+            continue;
+        }
 
-            if !config.usedups && record.is_duplicate() {
-                counts.duplicated += 1;
-                continue;
-            }
+        if !config.usedups && record.is_duplicate() {
+            counts.duplicated += 1;
+            continue;
+        }
 
-            if record.mapq() < config.mapq {
-                counts.mapq += 1;
-                continue;
-            }
+        if record.mapq() < config.mapq {
+            counts.mapq += 1;
+            continue;
+        }
 
-            if let Some(ref_chr_id) = tid_map[record.tid() as usize] {
-                let ref_chr_map = &genemap.intervals[ref_chr_id];
-                if record.is_paired() {
-                    if record.is_mate_unmapped() {
-                        if !config.nosingletons {
-                            counts.count_hit(&map_segments(&record, ref_chr_map, config));
-                        }
-                    } else if record.tid() != record.mtid() {
-                        // not same chromosome? then this read pair is ambiguous
-                        counts.ambiguous_pair += 1;
-                    } else if let Some(mate) = delayed.remove(record.qname()) {
-                        let m1 = map_segments(&record, ref_chr_map, config);
-                        let m2 = map_segments(&mate, ref_chr_map, config);
-                        if m1 == m2 {
-                            counts.count_hit(&m1);
-                        } else {
-                            counts.ambiguous_pair += 1;
-                        }
+        if let Some(ref_chr_id) = tid_map[record.tid() as usize] {
+            let ref_chr_map = &genemap.intervals[ref_chr_id];
+            if record.is_paired() {
+                if record.is_mate_unmapped() {
+                    if !config.nosingletons {
+                        counts.count_hit(&map_segments(&record, ref_chr_map, config));
+                    }
+                } else if record.tid() != record.mtid() {
+                    // not same chromosome? then this read pair is ambiguous
+                    counts.ambiguous_pair += 1;
+                } else if let Some(mate) = delayed.remove(record.qname()) {
+                    let m1 = map_segments(&record, ref_chr_map, config);
+                    let m2 = map_segments(&mate, ref_chr_map, config);
+                    if m1 == m2 {
+                        counts.count_hit(&m1);
                     } else {
-                        delayed.insert(record.qname().to_vec(), record);
+                        counts.ambiguous_pair += 1;
                     }
                 } else {
-                    //Single-end read
-                    counts.count_hit(&map_segments(&record, ref_chr_map, config));
+                    delayed.insert(record.qname().to_vec(), record);
                 }
             } else {
-                // this chr was not in the gtf
-                counts.notingtf += 1;
+                //Single-end read
+                counts.count_hit(&map_segments(&record, ref_chr_map, config));
             }
+        } else {
+            // this chr was not in the gtf
+            counts.notingtf += 1;
+        }
     }
     Ok(counts)
 }
 
-fn map_segments(r: &bam::Record, map: &NClist<Exon>, config: &Config) -> SegmentHit {
+fn map_segments(r: &bam::Record, map: &NClist<Section>, config: &Config) -> SegmentHit {
     //Store the first gene hit id
-    let mut  target_id = None;
+    let mut target_id = None;
     let cigar = r.cigar();
 
     let strict = config.method == QuantMethod::Strict;
     let strandness = config.strandness;
 
     // use cigar line to filter the cigar to ranges (o) that lie on the genome
-    for o in cigar.into_iter().scan(r.pos(), |pos, c| {
-        match c {
+    for o in cigar
+        .into_iter()
+        .scan(r.pos(), |pos, c| match c {
             Cigar::Del(n) | Cigar::RefSkip(n) => {
                 *pos += *n as i64;
                 Some(None)
-            },
-            Cigar::Ins(_) | Cigar::SoftClip(_) | Cigar::HardClip(_) | Cigar::Pad(_) => {
-                Some(None)
-            },
+            }
+            Cigar::Ins(_) | Cigar::SoftClip(_) | Cigar::HardClip(_) | Cigar::Pad(_) => Some(None),
             Cigar::Match(n) | Cigar::Equal(n) | Cigar::Diff(n) => {
                 let r = *pos..*pos + *n as i64;
                 *pos += *n as i64;
                 Some(Some(r))
             }
-        }
-    }).flatten()
+        })
+        .flatten()
     {
-        //match this segment's genomic region to exons and filter based on program configuration
-        let exons =  map.overlaps(&o)
+        //match this segment's genomic region to sections and filter based on program configuration
+        let sections = map
+            .overlaps(&o)
             .filter(|e| !strict || (o.start >= *e.start() && o.end <= *e.end()))
             .filter(|e| strandness.matches_bam_record(r, e.strand));
 
-        // check that all overlapping exons map to the same gene
+        // check that all overlapping sections map to the same gene
         let mut segment_ambiguous = false;
         let mut segment_id = None;
 
-        for exon in exons {
+        for section in sections {
             if let Some(id) = segment_id {
-                if !strict && (id != exon.id) {
+                if !strict && (id != section.id) {
                     // in  union mode any part linking to a different gene makes it ambiguous
                     return SegmentHit::Ambiguous;
-                } else if strict && id != exon.id {
-                    // in strict mode ambigous segments can be recued if a unique mapping is 
+                } else if strict && id != section.id {
+                    // in strict mode ambigous segments can be recued if a unique mapping is
                     // available from other segments
                     segment_ambiguous = true;
                     break;
-                } 
+                }
             } else {
-                segment_id = Some(exon.id)
+                segment_id = Some(section.id)
             }
         }
 
@@ -388,12 +418,12 @@ fn map_segments(r: &bam::Record, map: &NClist<Exon>, config: &Config) -> Segment
 
         if !segment_ambiguous {
             if target_id.is_some() && segment_id.is_some() && target_id != segment_id {
-                return SegmentHit::Ambiguous
+                return SegmentHit::Ambiguous;
             }
             if target_id.is_none() && segment_id.is_some() {
                 target_id = segment_id;
             }
-        } 
+        }
     }
 
     if let Some(id) = target_id {
@@ -402,4 +432,3 @@ fn map_segments(r: &bam::Record, map: &NClist<Exon>, config: &Config) -> Segment
         SegmentHit::Nohit
     }
 }
-

--- a/src/app.rs
+++ b/src/app.rs
@@ -140,7 +140,7 @@ impl GeneMap {
     pub fn from_gtf(config: &Config) -> Result<GeneMap> {
         //open gtf
         let t0 = Instant::now();
-        let (r, _compression) = niffler::from_path(config.gtf.as_str())?;
+        let (r, _compression) = niffler::from_path(config.gtf.as_path())?;
         let mut reader = GtfReader::new(r);
 
         let mut genes = IndexSet::new();

--- a/src/gtf.rs
+++ b/src/gtf.rs
@@ -159,7 +159,8 @@ mod test {
     fn read() {
         let mut reader = GtfReader::new(Cursor::new(GTF));
         let mut record = GtfRecord::new();
-        let seq_types = ["exon".to_string()].iter().collect::<HashSet<String>>();
+        let mut seq_types = HashSet::new();
+        seq_types.insert("exon".to_string());
 
         //gene entry
         assert!(matches!(reader.read_record(&mut record), Ok(n) if n > 0));

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,40 +72,28 @@ fn parse_seq_types(s: &str) -> Result<HashSet<String>, String> {
                     return Err("\"gene\" overlaps other seq_types".to_string());
                 }
             }
-            "mRNA" => {
-                if !seq_types.is_disjoint(
-                    &["exon", "gene", "cds", "five_prime_UTR", "three_prime_UTR"]
-                        .iter()
-                        .map(|s| s.to_string())
-                        .collect(),
-                ) {
+            "CDS" => {
+                if ["exon", "gene", "transcript"].iter().any(|&x| seq_types.contains(x)) {
                     return Err("\"mRNA\" overlaps other requested seq_types".to_string());
                 }
             }
-            "cds" => {
-                if !seq_types.is_disjoint(
-                    &["exon", "gene", "mRNA"]
-                        .iter()
-                        .map(|s| s.to_string())
-                        .collect(),
-                ) {
+            "transcript" => {
+                if ["exon", "gene", "CDS"].iter().any(|&x| seq_types.contains(x)) {
                     return Err("\"mRNA\" overlaps other requested seq_types".to_string());
                 }
             }
-            "exon" | "intron" | "polyA_sequence" | "polyA_site" | "five_prime_UTR"
-            | "three_prime_UTR" => {
+            "exon" | "stop_codon" | "start_codon" | "five_prime_UTR" | "three_prime_UTR" | "Selenocysteine" => {
                 if seq_types.contains("gene") {
-                    return Err("\"gene\" overlaps other seq_types".to_string());
-                } else if seq_types.contains("mRNA") && part != "intron" && !part.contains("polyA")
-                {
-                    return Err("\"mRNA\" overlaps other seq_types".to_string());
-                } else if seq_types.contains("cds") && part == "exon" {
-                    return Err("\"cds\" overlaps with exons".to_string());
+                    return Err(format!("\"gene\" overlaps with {part}"));
+                } else if seq_types.contains("transcript") && !part.contains("UTR") {
+                    return Err(format!("\"transcript\" overlaps with {part}"));
+                } else if seq_types.contains("CDS") && part == "exon" {
+                    return Err("\"CDS\" overlaps with exon".to_string());
                 }
             }
             _ => {
                 return Err(r#"
-Use one of "exon", "gene", "mRNA", "cds", "intron", "polyA_sequence", "polyA_site", "five_prime_UTR" and "three_prime_UTR"."#.to_string())
+Use one of "exon", "transcript", "CDS", "gene", "stop_codon", "start_codon", "five_prime_UTR", "three_prime_UTR", "transcript" and "Selenocysteine"."#.to_string())
             }
         }
         if !seq_types.insert(part.to_string()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 use std::fs::File;
 use std::io;
+use std::str::FromStr;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
@@ -15,7 +17,7 @@ use app::{quantify_bam, GeneMap, QuantMethod, Strandness};
 pub struct Config {
     /// The .gtf reference transcriptome file.
     #[arg(short = 'f', long, value_name = "FILE", required = true)]
-    gtf: String,
+    gtf: PathBuf,
 
     /// The bam file to quantify.
     #[arg(short, long, value_name = "FILE", required = true)]
@@ -23,42 +25,42 @@ pub struct Config {
 
     /// The output file
     #[arg(short, long, value_name = "FILE", required = false)]
-    output: Option<String>,
+    output: Option<PathBuf>,
 
     /// The minimum required mapping quality to include.
     #[arg(short = 'q', long, value_name = "0-255", default_value = "10", value_parser = clap::value_parser!(u8).range(..256))]
     mapq: u8,
 
     /// The RNA library strandness [F]orward, [R]everse or [U]nstranded.
-    #[arg(value_enum, short, long, default_value = "U")]
+    #[arg(value_enum, short, long, default_value = "U", value_parser = Strandness::from_str)]
     strandness: Strandness,
 
-    /// The quantification method, 'strict' or 'union'. 'union' counts all
-    /// genes that overlap any part of the reads, 'strict' requires the read to
-    /// map within the exon boundaries.
-    #[arg(value_enum, short = 'm', long = "method", default_value = "union")]
+    /// The quantification method. 'union' counts all genes that overlap any
+    /// part of the reads, 'strict' requires the read to map within the exon
+    /// boundaries.
+    #[arg(value_enum, short = 'm', long = "method", default_value = "union", verbatim_doc_comment)]
     method: QuantMethod,
-
-    /// Also count read (pairs) marked as (optical) duplicate, default excludes
-    /// duplicates. Requires a bam files processed with a markdups tool.
-    #[arg(short = 'd', long)]
-    usedups: bool,
-
-    /// Do not count paired-end reads that have only 1 mapped end.
-    /// Default allows one mapped end. Only affects paired-end reads.
-    #[arg(short = 'n', long)]
-    nosingletons: bool,
-
-    /// Include supplementary reads. Secondary reads (alternate alignments) not
-    /// included.
-    #[arg(short = 's', long)]
-    use_supplementary: bool,
 
     /// A comma seperated list of sequence types. Allowed are non overlapping:
     /// exon, gene, mRNA, cds, intron, polyA_sequence, polyA_site, five_prime_UTR
     /// and three_prime_UTR.
-    #[arg(short = 'T', long, default_value = "exon", value_parser = parse_seq_types)]
+    #[arg(short = 'T', long, default_value = "exon", value_parser = parse_seq_types, verbatim_doc_comment)]
     seq_types: HashSet<String>,
+
+    /// Also count read (pairs) marked as (optical) duplicate, default excludes
+    /// duplicates. Requires a bam files processed with a markdups tool.
+    #[arg(short = 'd', long, verbatim_doc_comment)]
+    usedups: bool,
+
+    /// Do not count paired-end reads that have only 1 mapped end.
+    /// Default allows one mapped end. Only affects paired-end reads.
+    #[arg(short = 'n', long, verbatim_doc_comment)]
+    nosingletons: bool,
+
+    /// Include supplementary reads. Secondary reads (alternate alignments) not
+    /// included.
+    #[arg(short = 's', long, verbatim_doc_comment)]
+    use_supplementary: bool,
 }
 
 fn parse_seq_types(s: &str) -> Result<HashSet<String>, String> {
@@ -102,10 +104,8 @@ fn parse_seq_types(s: &str) -> Result<HashSet<String>, String> {
                 }
             }
             _ => {
-                return Err(format!(
-                    r#"
-Use one of "exon", "gene", "mRNA", "cds", "intron", "polyA_sequence", "polyA_site", "five_prime_UTR" and "three_prime_UTR"."#
-                ))
+                return Err(r#"
+Use one of "exon", "gene", "mRNA", "cds", "intron", "polyA_sequence", "polyA_site", "five_prime_UTR" and "three_prime_UTR"."#.to_string())
             }
         }
         if !seq_types.insert(part.to_string()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,18 +83,16 @@ fn parse_seq_types(s: &str) -> Result<HashSet<String>, String> {
                 } else if seq_types.contains("cds") && part == "exon" {
                     return Err("\"cds\" overlaps with exons".to_string());
                 }
-                if !seq_types.insert(part.to_string()) {
-                    eprintln!("duplicate seq-type {part}");
-                }
             }
             _ => {
                 return Err(format!(
                     r#"
-    {part}? supported are --seq-types "exon", "gene", "mRNA", "cds", "intron", "polyA_sequence"
-    "polyA_site", "five_prime_UTR" and "three_prime_UTR".
-"#
+Use one of "exon", "gene", "mRNA", "cds", "intron", "polyA_sequence", "polyA_site", "five_prime_UTR" and "three_prime_UTR"."#
                 ))
             }
+        }
+        if !seq_types.insert(part.to_string()) {
+            eprintln!("duplicate seq-type {part}");
         }
     }
     Ok(seq_types)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,107 +1,53 @@
 use std::fs::File;
 use std::io;
 
-use clap::{crate_authors, crate_version, App, Arg};
-use anyhow::{Result, Context};
+use clap::Parser;
+use anyhow::Result;
 
 mod gtf;
 mod app;
 
-use app::{GeneMap, Config, quantify_bam};
+use app::{GeneMap, quantify_bam, Strandness, QuantMethod};
+
+#[derive(Debug, Clone, Parser)]
+#[command(author, version, about)]
+pub struct Config {
+    #[arg(short = 'f', long, value_name = "FILE", required = true)]
+    gtf: String,
+
+    #[arg(short, long, value_name = "FILE", required = true)]
+    bam: String,
+
+    #[arg(short, long, value_name = "FILE", required = false)]
+    output: Option<String>,
+
+    #[arg(short = 'q', long, value_name = "0-255", default_value = "10", value_parser = clap::value_parser!(u8).range(..256))]
+    mapq: u8,
+
+    #[arg(value_enum, short, long, default_value = "U")]
+    strandness: Strandness,
+
+    #[arg(value_enum, short = 'm', long = "method", default_value = "union")]
+    method: QuantMethod,
+
+    #[arg(short = 'd', long)]
+    usedups: bool,
+
+    #[arg(short = 's', long)]
+    use_supplementary: bool,
+
+    #[arg(short = 'n', long)]
+    nosingletons: bool,
+}
 
 fn main() -> Result<()> {
-    let matches = App::new("gensum")
-        .author(crate_authors!())
-        .version(crate_version!())
-        .arg(Arg::with_name("gtf")
-                 .help("The .gtf reference transcriptome file")
-                 .long("gtf")
-                 .short("f")
-                 .required(true)
-                 .takes_value(true)
-                 .value_name("FILE"))
-        .arg(Arg::with_name("bam")
-                 .help("The bam file to quantify")
-                 .long("bam")
-                 .short("b")
-                 .required(true)
-                 .takes_value(true)
-                 .value_name("FILE"))
-        .arg(Arg::with_name("output")
-                 .help("The output file")
-                 .long("output")
-                 .short("o")
-                 .required(false)
-                 .takes_value(true)
-                 .value_name("FILE"))
-        .arg(Arg::with_name("mapq")
-                 .help("The minimum required mapping quality to include")
-                 .long("mapq")
-                 .short("q")
-                 .required(false)
-                 .takes_value(true)
-                 .default_value("10")
-                 .value_name("0-255"))
-        .arg(Arg::with_name("strandness")
-                 .help("The RNA library strandness [F]orward, [R]everse or [U]nstranded")
-                 .long("strandness")
-                 .short("s")
-                 .required(false)
-                 .takes_value(true)
-                 .possible_values(&["F", "R", "U"])
-                 .default_value("U"))
-        .arg(Arg::with_name("qmethod")
-                 .help("The quantification method, 'strict' or 'union'. 'union' counts all \
-                     genes that overlap any part of the reads, 'strict' requires the read to \
-                     map within the exon boundaries.")
-                 .long("method")
-                 .short("m")
-                 .required(false)
-                 .takes_value(true)
-                 .possible_values(&["union", "strict"])
-                 .default_value("union"))
-        .arg(Arg::with_name("usedups")
-                 .help("Also count read (pairs) marked as (optical) duplicate, default \
-                     excludes duplicates. Requires a bam files processed with a markdups tool")
-                 .long("usedups")
-                 .short("d")
-                 .required(false)
-                 .takes_value(false))
-        .arg(Arg::with_name("nosingletons")
-                 .help("Do not count paired-end reads that have only 1 mapped end. \
-                     Default allows one mapped end. Only affects paired-end reads.")
-                 .long("nosingle")
-                 .short("n")
-                 .required(false)
-                 .takes_value(false))
-        .get_matches();
+    let config = Config::parse();
 
-    let usedups = matches.is_present("usedups");
-    let nosingletons = matches.is_present("nosingletons");
-    let mapq: u8 = matches
-        .value_of("mapq")
-        .unwrap()
-        .parse()
-        .context("Min mapq cutoff value should be 0-255")?;
+    let gm = GeneMap::from_gtf(config.gtf.as_str())?;
 
-    let strandness = matches.value_of("strandness").unwrap().parse().unwrap();
-    let method = matches.value_of("qmethod").unwrap().parse().unwrap();
+    let res = quantify_bam(&config, &gm)?;
 
-    let config = Config { 
-        usedups,
-        nosingletons,
-        mapq,
-        method,
-        strandness
-    };
-
-    let r = matches.value_of_os("gtf").unwrap();
-    let gm = GeneMap::from_gtf(r)?;
-
-    let bam = matches.value_of_os("bam").unwrap();
-    let res = quantify_bam(bam, config, &gm)?;
-
-    if let Some(f) = matches.value_of_os("output") {
+    if let Some(f) = config.output {
         let o = File::create(f)?;
         res.write(o, &gm)?;
     } else {


### PR DESCRIPTION
Allow accounting reads overlapping alternate or multiple sequence types than exon.
Checks should prevent specifying all sequence types that overlap one another.

Includes more changes to use clap derive and apply some cargo fmt changes.